### PR TITLE
Set PopupMenuItem to "reactive : false"

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -62,7 +62,7 @@ function resetPre() {
 
 function updateExtensionAppearence() {
     //Creates new PopupMenuItem
-    this.iconMenuItem = new PopupMenu.PopupMenuItem('');
+    this.iconMenuItem = new PopupMenu.PopupMenuItem('', {reactive : false});
     //Adds a box where we are going to store picture and avatar
     this.iconMenuItem.add_child(new St.BoxLayout({
                                     x_align: Clutter.ActorAlign.START,


### PR DESCRIPTION
With this setting the item won't be highlighted anymore when hovering on it. Since there's no onClick event associated with that item, the highlight seems unfitting.